### PR TITLE
pull status from response on fetch

### DIFF
--- a/bashrc-functions.sh
+++ b/bashrc-functions.sh
@@ -15,6 +15,8 @@ function log() {
 function find-config() {
   if [ -f ".cool-prompt/config.json" ]; then
     echo "${PWD%/}/.cool-prompt/config.json"
+  elif [ -f ".cool-prompt.json" ]; then
+    echo "${PWD%/}/.cool-prompt.json"
   elif [ "$PWD" = / ]; then
     echo $HOME/.cool-prompt/config.json 
   else
@@ -95,9 +97,7 @@ function wf-get() {
     status)
       WF_HOST=($(get-config HOST))
       for i in ${!WF_HOST[@]}; do
-        [[ "${WF_HOST[$i]}" = "github" ]] \
-          && conclusion-map $(get-attribute-gh "conclusion" $i) \
-          || conclusion-map $(get-attribute-gl "status" $i)
+        cat "/tmp/$(config-name $i)_last_status"
       done
       exit;;
     *)

--- a/fetch.sh
+++ b/fetch.sh
@@ -7,6 +7,7 @@ function github-workflow() {
   REPO=$(get-config-i $1 REPO)
   WF_NAME=$(get-config-i $1 WF_NAME)
   URL=$(get-config-i $1 URL)
+  NAME=$(config-name $1)
 
   if [ -z ${URL} ]; then
     log "URL unset, fetching"
@@ -20,18 +21,23 @@ function github-workflow() {
 
   curl -s -u ":$GH_PAT" -H "Accept: application/vnd.github.v3+json"  $URL/runs \
     2> $HOME/.cool-prompt/log \
-    1> "/tmp/$(config-name $1)"
+    1> "/tmp/$NAME"
+
+  jq -r '.workflow_runs[0].conclusion' "/tmp/$NAME" > "/tmp/${NAME}_last_status"
 }
 
 function gitlab-pipeline() {
   log "gitlab-workflow called"
 
   PROJECT_ID=$(get-config-i $1 PROJECT_ID)
+  NAME=$(config-name $1)
 
   curl -s -H "PRIVATE-TOKEN: $GL_PAT" \
     "https://gitlab.com/api/v4/projects/$PROJECT_ID/pipelines" \
     2> $HOME/.cool-prompt/log \
-    1> "/tmp/$(config-name $1)" 
+    1> "/tmp/$NAME" 
+
+  jq -r '.[0].status' "/tmp/$NAME" > "/tmp/${NAME}_last_status"
 }
 
 function config-paths() {


### PR DESCRIPTION
- stop calling jq to get the status for the prompt
  - this slows down the prompt the more statuses you need to fetch, fine for 1 or 2, noticeably slower for 4 or more 
- instead call jq from the cronjob and store the status in a separate file that can be grabbed by name
  - this also simplifies the wf-get function as it doesn't need to check the host type 